### PR TITLE
Round the window offset and shape to full pixels

### DIFF
--- a/src/cityblocks/_core.py
+++ b/src/cityblocks/_core.py
@@ -54,11 +54,6 @@ def extract_area(filename, bbox):
         )
         data = file.read(1, window=window)
 
-        import IPython
-
-        IPython.embed()
-        quit()
-
         # Get coordinates
         height, width = data.shape
         rows, cols = np.meshgrid(np.arange(height), np.arange(width), indexing="ij")

--- a/src/cityblocks/_core.py
+++ b/src/cityblocks/_core.py
@@ -47,8 +47,17 @@ def extract_area(filename, bbox):
         west, south, east, north = map(float, bbox.split(","))
 
         # Extract window
-        window = rasterio.windows.from_bounds(west, south, east, north, file.transform)
+        window = (
+            rasterio.windows.from_bounds(west, south, east, north, file.transform)
+            .round_offsets()
+            .round_lengths()
+        )
         data = file.read(1, window=window)
+
+        import IPython
+
+        IPython.embed()
+        quit()
 
         # Get coordinates
         height, width = data.shape


### PR DESCRIPTION
This PR rounds the bounding box so it aligns exactly with the raster of the input data. This should fix a problem where the pixels are shifted slightly with respect to the input data, as illustrated below:

![image](https://github.com/user-attachments/assets/8b44c794-90b0-4cc9-9395-26e8398f9ed0)
